### PR TITLE
ci: add major/minor release heading in GitHub release notes

### DIFF
--- a/.github/workflows/tag-after-merge.yml
+++ b/.github/workflows/tag-after-merge.yml
@@ -1,4 +1,7 @@
-name: Tag After Merge
+name: Tag and Release After Merge
+
+permissions:
+  contents: write
 
 on:
   push:
@@ -6,7 +9,7 @@ on:
       - main
 
 jobs:
-  create-tag:
+  create-tag-and-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -22,7 +25,6 @@ jobs:
       - name: Get last tag (if exists)
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          # strip leading "v" if present
           LAST_TAG_STRIPPED=${LAST_TAG#v}
           echo "last_tag=$LAST_TAG_STRIPPED" >> $GITHUB_ENV
 
@@ -49,7 +51,7 @@ jobs:
 
       - name: Skip if patch
         if: env.release_type == 'patch'
-        run: echo "Patch release detected → no tag will be created."
+        run: echo "Patch release detected → no tag or release will be created."
 
       - name: Create and push git tag
         if: env.release_type != 'patch'
@@ -58,3 +60,30 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag v${{ env.version }}
           git push origin v${{ env.version }}
+
+      - name: Extract release notes from CHANGELOG
+        if: env.release_type != 'patch'
+        id: changelog
+        run: |
+          # Match lines starting with "## vX.Y.Z " until the next "## "
+          awk "/^## v${{ env.version }}[[:space:]]/{flag=1; next} /^## /{flag=0} flag" CHANGELOG.md > RELEASE_NOTES.md
+        
+          echo "notes<<EOF" >> $GITHUB_ENV
+          if [ "${{ env.release_type }}" = "major" ]; then
+            echo "## 🚀 Major Release" >> $GITHUB_ENV
+          elif [ "${{ env.release_type }}" = "minor" ]; then
+            echo "## ✨ Minor Release" >> $GITHUB_ENV
+          fi
+          echo "" >> $GITHUB_ENV
+          cat RELEASE_NOTES.md >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create GitHub Release
+        if: env.release_type != 'patch'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ env.version }}
+          name: "Release v${{ env.version }}"
+          body: ${{ env.notes }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Updated release notes extraction to prepend heading based on release type
  - 🚀 Major Release
  - ✨ Minor Release
- Ensures GitHub release body includes contextual heading + changelog content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated creation of GitHub Releases for major/minor versions, including version tags and release notes.
  * Release notes are now generated from the changelog and included in the published release.
  * Patch updates are skipped for tagging and releasing to reduce noise.
  * Clearer workflow naming and messaging to reflect tagging and releasing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->